### PR TITLE
fix(graphdb): Remove incorrect GraphDB Sparql query

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1110,7 +1110,7 @@ WHERE {
  }
  $filterGraph
 }
-GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?distLabels ?graph
+GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?graph
 ORDER BY LCASE(STR(?match)) LANG(?match) LCASE(STR(?distLabels)) $orderextra
 EOQ;
         return $query;


### PR DESCRIPTION
GraphDB does not allow the query without this modification as 'distLabels' is already used.
